### PR TITLE
Handle missing state and country w/o an exception

### DIFF
--- a/app/models/spree/gateway/alpha_card_gateway.rb
+++ b/app/models/spree/gateway/alpha_card_gateway.rb
@@ -117,9 +117,9 @@ module Spree
           address1:  address.address1,
           address2:  address.address2,
           city:      address.city,
-          state:     address.state.abbr,
+          state:     address.state_text,
           zip:       address.zipcode,
-          country:   address.country.iso,
+          country:   address.country.try(:iso),
           phone:     address.phone,
         )
       end


### PR DESCRIPTION
`state` can be `nil`, so can be the `country`. I make sure the code doesn't explode if it happens.

Take a look for reference:
https://github.com/spree/spree/blob/v3.0.7/core/app/models/spree/address.rb#L77